### PR TITLE
Add git instructions for contributors

### DIFF
--- a/Contributing.MD
+++ b/Contributing.MD
@@ -8,23 +8,25 @@
 
 **1) Create a fork of the project to your GitHub account.**
 
-**2) Install the tool by following steps(a-h)**
+**2) Install the tool by following steps(a-i)**
 
     a) Click on "Clone or download" and the click "Download zip".
+
+    b) Navigate to the folder containing the zip, and extract the zipped files. (Right click on the zipped folder -> "Extract All")
     
-    b) Open Chrome and click on the icon(⋮)in the top right corner.
+    c) Open Chrome and click on the icon(⋮)in the top right corner.
     
-    c) Click on “More tools” -> “Extensions”.
+    d) Click on “More tools” -> “Extensions”.
     
-    d) Enable on developer mode by checking the “Developer Mode” slider in the top right.
+    e) Enable on developer mode by checking the “Developer Mode” slider in the top right.
     
-    e) Click on “Load unpacked extension” under the search bar.
+    f) Click on “Load unpacked extension” under the search bar.
     
-    f) Select the folder you saved the extracted file and click "ok". 
+    g) Select the folder you saved the extracted file and click "ok". 
     
-    g) Click on “Update ” under the search bar.
+    h) Click on “Update ” under the search bar.
     
-    h) A new extension called ”GenderMag Recorder's Assistant” should be in the top left corner of the extensions.
+    i) A new extension called ”GenderMag Recorder's Assistant” should be in the top left corner of the extensions.
     
 **3) If you want to run the tool at this point, navigate to the page you wish to perform GenderMag on and click the maroon GenderMag button at the bottom of the screen. (See the video at http://gendermag.org for examples of running it.)**
 

--- a/Contributing.MD
+++ b/Contributing.MD
@@ -45,3 +45,9 @@
 
 ## IMPORTANT:
 By submitting a patch,you agree to allow the project owner to license your work under the same license as that used by the project.
+
+## Contributors
+
+Please see the
+[Contributors Graph](https://github.com/mendezc1/GenderMagRecordersAssistant/graphs/contributors) for our
+list of contributors.

--- a/Contributing.MD
+++ b/Contributing.MD
@@ -1,5 +1,9 @@
 # This is the GenderMag Recorder's Assistant Contributing.MD
 
+## Git Resources
+
+* Please review the resources available at https://try.github.io/ if you are not already familiar with Git/GitHub or need a reference for Git terms and commands as you prepare to contribute.
+
 ## How to install:
 
 **1) Create a fork of the project to your GitHub account.**

--- a/README.md
+++ b/README.md
@@ -39,13 +39,6 @@ We welcome everyone with any background to contribute to making the world of sof
 
 Please follow our [Code Of Conduct](https://github.com/mendezc1/GenderMagRecordersAssistant/blob/master/Code_of_Conduct.md) and read our [Contributing Guide](https://github.com/mendezc1/GenderMagRecordersAssistant/blob/master/Contributing.MD).
 
-
-## Contributors
-
-Please see the
-[Contributors Graph](https://github.com/mendezc1/GenderMagRecordersAssistant/graphs/contributors) for our
-list of contributors.
-
 ## Resource
 
 * Chrome Extension link: [GenderMag Recorder's Assistant](https://chrome.google.com/webstore/detail/gendermag-recorders-assis/efacfbjnfhfaplaglplaljdleimiiflf?hl=en)


### PR DESCRIPTION
---
name: Pull request template
about: GenderMag Recorders Assistant project

---

* **What does this implementation fix? Explain your changes.**
	This implementation aims to make the readme and contributing guide more inclusive to Abi personas by adding a link to a Git/GitHub tutorial and nesting the Contributor Graph link inside of the Contributing guide instead of having it featured in the README
	
	
* **Does this close any currently open issue? (Give issue id from issue tracker)**
No


* **Include any related logs, error, output file etc.**
None


* **Any other information?**
No
