### PR TITLE
Updated with example session video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We welcome everyone with any background to contribute to making the world of sof
     
     h) A new extension called ”GenderMag Recorder's Assistant” should be in the top left corner of the extensions.
     
-3) If you want to run the tool at this point, navigate to the page you wish to perform GenderMag on and click the maroon GenderMag button at the bottom of the screen. (See the video at http://gendermag.org for examples of running it.)
+3) If you want to run the tool at this point, navigate to the page you wish to perform GenderMag on and click the maroon GenderMag button at the bottom of the screen. (See the [video](http://gendermag.org/GenderMag%20Demonstration.mp4) from http://gendermag.org for examples of running it.
 
 ## Contributing
 


### PR DESCRIPTION
---
name: Pull request template
about: GenderMag Recorders Assistant project

---

* **What does this implementation fix? Explain your changes.**
	When users are trying to learn how to use the recorder, users may want a video tutorial. However, it is hard to find the video through the original link at http://gendermag.org. This provides a direct link to the GenderMag example session for users. 

* **Does this close any currently open issue? (Give issue id from issue tracker)**
Issue#33

* **Include any related logs, error, output file etc.**
N/A


* **Any other information?**
N/A
